### PR TITLE
ci: обновлены рантайм Node и версии экшенов

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -13,15 +13,19 @@ on:
         default: ''
         description: 'Имя тега для сборки (например, v1.2.3), ветки или коммита. Если не указано, используется текущий ref'
 
+env:
+  # Active LTS: с 28.10.2025, EOL 28.04.2028
+  NODE_VERSION: '24'
+
 jobs:
   run-ci:
     runs-on: ubuntu-latest
     container:
-      image: node:20-bullseye
+      image: node:24-bookworm
 
     steps:
       - name: 🛒 Checkout with param
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.ref }}
@@ -32,9 +36,9 @@ jobs:
           git status --porcelain
 
       - name: ✨ Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
       - name: 📦 Install dependencies
@@ -43,9 +47,12 @@ jobs:
       - name: 📝 Lint
         run: npm run lint
 
+      - name: 🎨 Check formatting
+        run: npm run format:check
+
       - name: 🏗️ Build and cache
         id: cache-build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: dist/
           key: build-${{ gitea.sha }}-${{ hashFiles('src/**', 'package.json') }}

--- a/.gitea/workflows/publish-manual.yml
+++ b/.gitea/workflows/publish-manual.yml
@@ -18,6 +18,8 @@ on:
 env:
   # Active LTS: с 28.10.2025, EOL 28.04.2028
   NODE_VERSION: '24'
+  REGISTRY_URL: 'https://192.168.100.252:3000/api/packages/usov-andrey/npm/'
+  NPM_SCOPE: '@andrey-aka-skif'
 
 jobs:
   validate:
@@ -111,8 +113,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: 'https://192.168.100.252:3000/api/packages/usov-andrey/npm/'
-          scope: '@andrey-aka-skif'
+          registry-url: ${{ env.REGISTRY_URL }}
+          scope: ${{ env.NPM_SCOPE }}
 
       - name: 🚀 Publish package to Gitea Registry
         run: npm publish --tag "${{ inputs.npm_tag }}"

--- a/.gitea/workflows/publish-manual.yml
+++ b/.gitea/workflows/publish-manual.yml
@@ -15,18 +15,22 @@ on:
         default: replay
         type: string
 
+env:
+  # Active LTS: с 28.10.2025, EOL 28.04.2028
+  NODE_VERSION: '24'
+
 jobs:
   validate:
     runs-on: ubuntu-latest
     container:
-      image: node:20-bullseye
+      image: node:24-bookworm
     outputs:
       ref: ${{ steps.set-ref.outputs.ref }}
       version: ${{ steps.set-ref.outputs.version }}
 
     steps:
       - name: 🛒 Checkout (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -64,7 +68,7 @@ jobs:
 
   ci:
     needs: validate
-    uses: './.github/workflows/ci.yml'
+    uses: './.gitea/workflows/ci.yml'
     with:
       ref: ${{ needs.validate.outputs.ref }}
 
@@ -72,11 +76,11 @@ jobs:
     needs: [validate, ci]
     runs-on: ubuntu-latest
     container:
-      image: node:20-bullseye
+      image: node:24-bookworm
 
     steps:
       - name: 🛒 Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ needs.validate.outputs.ref }}
@@ -88,7 +92,7 @@ jobs:
 
       - name: 📥 Restore build from cache
         id: restore-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: dist/
           key: build-${{ gitea.sha }}-${{ hashFiles('src/**', 'package.json') }}
@@ -104,9 +108,9 @@ jobs:
           echo "✅ Сборка найдена в dist/"
 
       - name: ✨ Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://192.168.100.252:3000/api/packages/usov-andrey/npm/'
           scope: '@andrey-aka-skif'
 

--- a/.gitea/workflows/publish-on-tag.yml
+++ b/.gitea/workflows/publish-on-tag.yml
@@ -6,6 +6,10 @@ on:
   push:
     tags: ['v*.*.*']
 
+env:
+  # Active LTS: с 28.10.2025, EOL 28.04.2028
+  NODE_VERSION: '24'
+
 jobs:
   ci:
     uses: './.gitea/workflows/ci.yml'
@@ -16,11 +20,11 @@ jobs:
     needs: ci
     runs-on: ubuntu-latest
     container:
-      image: node:20-bullseye
+      image: node:24-bookworm
 
     steps:
       - name: 🛒 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -38,7 +42,7 @@ jobs:
 
       - name: 📥 Restore build from cache
         id: restore-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: dist/
           key: build-${{ gitea.sha }}-${{ hashFiles('src/**', 'package.json') }}
@@ -54,9 +58,9 @@ jobs:
           echo "✅ Сборка найдена в dist/"
 
       - name: ✨ Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://192.168.100.252:3000/api/packages/usov-andrey/npm/'
           scope: '@andrey-aka-skif'
 

--- a/.gitea/workflows/publish-on-tag.yml
+++ b/.gitea/workflows/publish-on-tag.yml
@@ -9,6 +9,8 @@ on:
 env:
   # Active LTS: с 28.10.2025, EOL 28.04.2028
   NODE_VERSION: '24'
+  REGISTRY_URL: 'https://192.168.100.252:3000/api/packages/usov-andrey/npm/'
+  NPM_SCOPE: '@andrey-aka-skif'
 
 jobs:
   ci:
@@ -61,8 +63,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: 'https://192.168.100.252:3000/api/packages/usov-andrey/npm/'
-          scope: '@andrey-aka-skif'
+          registry-url: ${{ env.REGISTRY_URL }}
+          scope: ${{ env.NPM_SCOPE }}
 
       - name: 🚀 Publish package to Gitea Registry
         run: npm publish --tag latest

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+
+version: 2
+updates:
+  # Без этого экшены снова тихо отстанут на несколько мажоров
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'ci'
+    groups:
+      github-actions:
+        patterns: ['*']
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: 'chore'
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
+        patterns: ['*']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,17 @@ on:
         default: ''
         description: 'Имя тега для сборки (например, v1.2.3), ветки или коммита. Если не указано, используется текущий ref'
 
+env:
+  # Active LTS: с 28.10.2025, EOL 28.04.2028
+  NODE_VERSION: '24'
+
 jobs:
   run-ci:
     runs-on: ubuntu-latest
 
     steps:
       - name: 🛒 Checkout with param
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.ref }}
@@ -30,9 +34,9 @@ jobs:
           git status --porcelain
 
       - name: ✨ Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
       - name: 📦 Install dependencies
@@ -41,9 +45,12 @@ jobs:
       - name: 📝 Lint
         run: npm run lint
 
+      - name: 🎨 Check formatting
+        run: npm run format:check
+
       - name: 🏗️ Build and cache
         id: cache-build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: dist/
           key: build-${{ github.sha }}-${{ hashFiles('src/**', 'package.json') }}

--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -15,6 +15,10 @@ on:
         default: replay
         type: string
 
+env:
+  # Active LTS: с 28.10.2025, EOL 28.04.2028
+  NODE_VERSION: '24'
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -24,7 +28,7 @@ jobs:
 
     steps:
       - name: 🛒 Checkout (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -68,10 +72,13 @@ jobs:
   publish:
     needs: [validate, ci]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: 🛒 Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ needs.validate.outputs.ref }}
@@ -83,7 +90,7 @@ jobs:
 
       - name: 📥 Restore build from cache
         id: restore-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: dist/
           key: build-${{ github.sha }}-${{ hashFiles('src/**', 'package.json') }}
@@ -99,9 +106,9 @@ jobs:
           echo "✅ Сборка найдена в dist/"
 
       - name: ✨ Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: https://npm.pkg.github.com
           scope: '@andrey-aka-skif'
 

--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -18,6 +18,8 @@ on:
 env:
   # Active LTS: с 28.10.2025, EOL 28.04.2028
   NODE_VERSION: '24'
+  REGISTRY_URL: 'https://npm.pkg.github.com'
+  NPM_SCOPE: '@andrey-aka-skif'
 
 jobs:
   validate:
@@ -109,8 +111,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: https://npm.pkg.github.com
-          scope: '@andrey-aka-skif'
+          registry-url: ${{ env.REGISTRY_URL }}
+          scope: ${{ env.NPM_SCOPE }}
 
       - name: 🚀 Publish package to Github Registry
         run: npm publish --tag "${{ inputs.npm_tag }}"

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -9,6 +9,8 @@ on:
 env:
   # Active LTS: с 28.10.2025, EOL 28.04.2028
   NODE_VERSION: '24'
+  REGISTRY_URL: 'https://npm.pkg.github.com'
+  NPM_SCOPE: '@andrey-aka-skif'
 
 jobs:
   ci:
@@ -62,8 +64,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-          registry-url: https://npm.pkg.github.com
-          scope: '@andrey-aka-skif'
+          registry-url: ${{ env.REGISTRY_URL }}
+          scope: ${{ env.NPM_SCOPE }}
 
       - name: 🚀 Publish package to Github Registry
         run: npm publish --tag latest

--- a/.github/workflows/publish-on-tag.yml
+++ b/.github/workflows/publish-on-tag.yml
@@ -6,6 +6,10 @@ on:
   push:
     tags: ['v*.*.*']
 
+env:
+  # Active LTS: с 28.10.2025, EOL 28.04.2028
+  NODE_VERSION: '24'
+
 jobs:
   ci:
     uses: './.github/workflows/ci.yml'
@@ -21,7 +25,7 @@ jobs:
 
     steps:
       - name: 🛒 Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -39,7 +43,7 @@ jobs:
 
       - name: 📥 Restore build from cache
         id: restore-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: dist/
           key: build-${{ github.sha }}-${{ hashFiles('src/**', 'package.json') }}
@@ -55,9 +59,9 @@ jobs:
           echo "✅ Сборка найдена в dist/"
 
       - name: ✨ Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: https://npm.pkg.github.com
           scope: '@andrey-aka-skif'
 


### PR DESCRIPTION
Closes #65

## Зачем

CI собирал пакет на Node 20, снятом с поддержки 30.04.2026. Экшены при этом
отстали на три мажора.

## Что изменено

**Node 20 → 24.** Active LTS: с 28.10.2025, EOL 28.04.2028. Node 22 уже в
maintenance, Node 26 станет LTS только 28.10.2026. Версия вынесена в
`env.NODE_VERSION`.

**Экшены.** `checkout` v4 → v7, `setup-node` v4 → v7, `cache` и
`cache/restore` v4 → v6.

**Адреса реестров** подняты в `env` публикующих воркфлоу — они меняются, и в
заголовке файла должно быть видно, куда идёт публикация. Образ контейнера в
Gitea остался литералом: в `jobs.<id>.container.image` контекст `env`
недоступен.

**Прочее.** Шаг `format:check` в `ci.yml` — без него снятые в #64 исключения
для yml ничем не подкреплены. Блок `permissions` в `publish-manual.yml`
(GitHub) — в парном воркфлоу он был, здесь отсутствовал. Добавлен
`dependabot.yml`: отставание на три мажора накопилось из-за его отсутствия.

## Найдено попутно

`.gitea/workflows/publish-manual.yml` вызывал переиспользуемый воркфлоу по
пути `./.github/workflows/ci.yml` вместо `./.gitea/` — ручная публикация в
Gitea прогоняла не тот CI. Исправлено.

## Проверка

YAML всех семи файлов парсится, `format:check` чистый, литеральных `node:20`
и `@v4` в дереве не осталось. Остальное проверяется только прогоном — пуш
ветки запустит `ci.yml` на обеих площадках.

## На что смотреть

**Основной риск — Gitea.** `setup-node@v7` и `cache@v6` переехали на ESM, а у
Gitea свой cache-сервер и свой рантайм JS-экшенов. Изменения по GitHub и
Gitea намеренно разнесены по коммитам: если Gitea споткнётся, откатывается
только её коммит. Запасной вариант — вернуть в `.gitea/` `cache@v4` и
`setup-node@v4`, оставив Node 24 через образ контейнера.

**Dependabot** настроен на weekly с группировкой — один PR на экшены, один на
dev-зависимости. Если окажется шумно, увести на monthly.

Breaking changes в `checkout` (дефолты `pull_request_target`) и `setup-node`
(убран `always-auth`) нас не касаются: не те триггеры, опция не
использовалась.