### PR TITLE
test: добавлены тесты билдеров

### DIFF
--- a/tests/builders/axios-error-builder.test.js
+++ b/tests/builders/axios-error-builder.test.js
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest'
+import {
+  fromAxios,
+  BaseAppError,
+  BadRequestError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  ConflictError,
+  InternalServerError,
+  DisconnectedError,
+  UnknownError,
+} from '../../src/index.js'
+
+/**
+ * Фикстура ошибки Axios с ответом сервера.
+ * Строится вручную, чтобы не тянуть axios в devDependencies.
+ */
+const serverError = (status, data) => ({
+  isAxiosError: true,
+  response: { status, data },
+})
+
+/** Фикстура ошибки Axios без ответа: запрос ушёл, ответа не было. */
+const networkError = () => ({
+  isAxiosError: true,
+  request: {},
+})
+
+const MAPPED_STATUSES = [
+  [400, BadRequestError],
+  [401, UnauthorizedError],
+  [403, ForbiddenError],
+  [404, NotFoundError],
+  [409, ConflictError],
+  [500, InternalServerError],
+]
+
+describe('fromAxios', () => {
+  describe('ответ сервера с известным статусом', () => {
+    it.each(MAPPED_STATUSES)(
+      'статус %i преобразуется в %s',
+      (status, ErrorClass) => {
+        const error = fromAxios(serverError(status, null))
+
+        expect(error).toBeInstanceOf(ErrorClass)
+        expect(error).toBeInstanceOf(BaseAppError)
+        expect(error.status).toBe(status)
+      }
+    )
+
+    it.each(MAPPED_STATUSES)(
+      'для статуса %i значение detail попадает в details',
+      status => {
+        const error = fromAxios(serverError(status, { detail: 'подробности' }))
+
+        expect(error.details).toBe('подробности')
+      }
+    )
+  })
+
+  describe('ответ сервера с неизвестным статусом', () => {
+    // 422, 429 и 5xx от прокси — самые частые из непокрытых. Сейчас все они
+    // схлопываются в UnknownError, теряя и статус, и тело ответа.
+    it.each([418, 422, 429, 502, 503, 504])(
+      'статус %i преобразуется в UnknownError',
+      status => {
+        const error = fromAxios(serverError(status, { detail: 'подробности' }))
+
+        expect(error).toBeInstanceOf(UnknownError)
+      }
+    )
+
+    it('исходный статус не сохраняется', () => {
+      const error = fromAxios(serverError(503, null))
+
+      expect(error.status).toBeUndefined()
+    })
+
+    it('тело ответа не сохраняется', () => {
+      const error = fromAxios(serverError(503, { detail: 'подробности' }))
+
+      expect(error.details).toBeNull()
+    })
+  })
+
+  describe('извлечение details из тела ответа', () => {
+    it.each([
+      ['data.detail', { detail: 'нижний регистр' }, 'нижний регистр'],
+      ['data.Detail', { Detail: 'верхний регистр' }, 'верхний регистр'],
+      ['всё тело, если ни detail, ни Detail нет', { code: 42 }, { code: 42 }],
+      ['строковое тело', 'просто текст', 'просто текст'],
+      ['пустая строка сохраняется как есть', { detail: '' }, ''],
+      ['null, если тело равно null', null, null],
+      ['null, если тела нет', undefined, null],
+    ])('%s', (_описание, data, expected) => {
+      const error = fromAxios(serverError(404, data))
+
+      expect(error.details).toEqual(expected)
+    })
+
+    it('detail имеет приоритет над Detail', () => {
+      const data = { detail: 'нижний', Detail: 'верхний' }
+      const error = fromAxios(serverError(404, data))
+
+      expect(error.details).toBe('нижний')
+    })
+
+    it('detail со значением null приводит к возврату всего тела', () => {
+      // Следствие ??: null не проходит, и цепочка доходит до самого data.
+      const data = { detail: null }
+      const error = fromAxios(serverError(404, data))
+
+      expect(error.details).toEqual(data)
+    })
+  })
+
+  describe('ошибки без ответа сервера', () => {
+    it('запрос без ответа преобразуется в DisconnectedError', () => {
+      const error = fromAxios(networkError())
+
+      expect(error).toBeInstanceOf(DisconnectedError)
+    })
+
+    it('таймаут преобразуется в DisconnectedError', () => {
+      // Таймаут неотличим от обрыва связи: у него тоже есть request и нет
+      // response, а code не проверяется.
+      const error = fromAxios({
+        isAxiosError: true,
+        code: 'ECONNABORTED',
+        request: {},
+      })
+
+      expect(error).toBeInstanceOf(DisconnectedError)
+    })
+
+    it('отменённый запрос преобразуется в UnknownError', () => {
+      const error = fromAxios({ isAxiosError: true, code: 'ERR_CANCELED' })
+
+      expect(error).toBeInstanceOf(UnknownError)
+    })
+
+    it('ошибка без response и без request преобразуется в UnknownError', () => {
+      const error = fromAxios({ isAxiosError: true })
+
+      expect(error).toBeInstanceOf(UnknownError)
+    })
+  })
+
+  describe('ошибки не от Axios', () => {
+    it('обычный Error преобразуется в UnknownError', () => {
+      const error = fromAxios(new Error('что-то пошло не так'))
+
+      expect(error).toBeInstanceOf(UnknownError)
+    })
+
+    it('произвольный объект преобразуется в UnknownError', () => {
+      const error = fromAxios({ response: { status: 404 } })
+
+      expect(error).toBeInstanceOf(UnknownError)
+    })
+  })
+
+  describe('некорректный вход', () => {
+    // Известный дефект (#66): билдер на пути обработки ошибок падает сам.
+    // Тесты написаны под ожидаемое поведение и станут зелёными после
+    // добавления гарда.
+    it.fails('null преобразуется в UnknownError', () => {
+      expect(fromAxios(null)).toBeInstanceOf(UnknownError)
+    })
+
+    it.fails('undefined преобразуется в UnknownError', () => {
+      expect(fromAxios(undefined)).toBeInstanceOf(UnknownError)
+    })
+
+    it('сейчас на null выбрасывается TypeError', () => {
+      expect(() => fromAxios(null)).toThrow(TypeError)
+    })
+  })
+})

--- a/tests/builders/superagent-error-builder.test.js
+++ b/tests/builders/superagent-error-builder.test.js
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest'
+import {
+  fromSuperagent,
+  BaseAppError,
+  BadRequestError,
+  UnauthorizedError,
+  ForbiddenError,
+  NotFoundError,
+  ConflictError,
+  InternalServerError,
+  DisconnectedError,
+  UnknownError,
+} from '../../src/index.js'
+
+/**
+ * Фикстура ошибки Superagent с ответом сервера.
+ * Билдер опознаёт такую ошибку по одновременному наличию body, response
+ * и statusText, поэтому все три поля обязательны.
+ */
+const serverError = (status, body) => ({
+  error: true,
+  body,
+  statusText: 'Error',
+  response: { status, body },
+})
+
+/**
+ * Фикстура недоступного сервера: Superagent не заполняет body, response
+ * и statusText.
+ */
+const disconnectError = () => ({
+  error: true,
+  message: 'connect ECONNREFUSED',
+})
+
+const MAPPED_STATUSES = [
+  [400, BadRequestError],
+  [401, UnauthorizedError],
+  [403, ForbiddenError],
+  [404, NotFoundError],
+  [409, ConflictError],
+  [500, InternalServerError],
+]
+
+describe('fromSuperagent', () => {
+  describe('ответ сервера с известным статусом', () => {
+    it.each(MAPPED_STATUSES)(
+      'статус %i преобразуется в %s',
+      (status, ErrorClass) => {
+        const error = fromSuperagent(serverError(status, null))
+
+        expect(error).toBeInstanceOf(ErrorClass)
+        expect(error).toBeInstanceOf(BaseAppError)
+        expect(error.status).toBe(status)
+      }
+    )
+
+    it.each(MAPPED_STATUSES.filter(([status]) => status !== 500))(
+      'для статуса %i значение detail попадает в details',
+      status => {
+        const error = fromSuperagent(
+          serverError(status, { detail: 'подробности' })
+        )
+
+        expect(error.details).toBe('подробности')
+      }
+    )
+
+    // Известный дефект (#66): ветка 500 создаёт InternalServerError без
+    // аргумента, в отличие от всех соседних и от axios-билдера.
+    it.fails('для статуса 500 значение detail попадает в details', () => {
+      const error = fromSuperagent(serverError(500, { detail: 'подробности' }))
+
+      expect(error.details).toBe('подробности')
+    })
+
+    it('сейчас для статуса 500 details теряется', () => {
+      const error = fromSuperagent(serverError(500, { detail: 'подробности' }))
+
+      expect(error.details).toBeNull()
+    })
+  })
+
+  describe('ответ сервера с неизвестным статусом', () => {
+    it.each([418, 422, 429, 502, 503, 504])(
+      'статус %i преобразуется в UnknownError',
+      status => {
+        const error = fromSuperagent(
+          serverError(status, { detail: 'подробности' })
+        )
+
+        expect(error).toBeInstanceOf(UnknownError)
+      }
+    )
+
+    it('исходный статус не сохраняется', () => {
+      const error = fromSuperagent(serverError(503, null))
+
+      expect(error.status).toBeUndefined()
+    })
+  })
+
+  describe('извлечение details из тела ответа', () => {
+    it.each([
+      ['body.detail', { detail: 'нижний регистр' }, 'нижний регистр'],
+      ['body.Detail', { Detail: 'верхний регистр' }, 'верхний регистр'],
+      ['всё тело, если ни detail, ни Detail нет', { code: 42 }, { code: 42 }],
+      ['пустая строка сохраняется как есть', { detail: '' }, ''],
+      ['null, если тело равно null', null, null],
+    ])('%s', (_описание, body, expected) => {
+      const error = fromSuperagent(serverError(404, body))
+
+      expect(error.details).toEqual(expected)
+    })
+
+    it('detail имеет приоритет над Detail', () => {
+      const body = { detail: 'нижний', Detail: 'верхний' }
+      const error = fromSuperagent(serverError(404, body))
+
+      expect(error.details).toBe('нижний')
+    })
+  })
+
+  describe('недоступность сервера', () => {
+    it('ошибка без body, response и statusText даёт DisconnectedError', () => {
+      const error = fromSuperagent(disconnectError())
+
+      expect(error).toBeInstanceOf(DisconnectedError)
+    })
+
+    it.each(['body', 'response', 'statusText'])(
+      'отсутствия одного только поля %s достаточно для DisconnectedError',
+      missing => {
+        const error = serverError(404, { detail: 'подробности' })
+        delete error[missing]
+
+        expect(fromSuperagent(error)).toBeInstanceOf(DisconnectedError)
+      }
+    )
+
+    it('таймаут преобразуется в DisconnectedError', () => {
+      // Флаг timeout не проверяется: срабатывает та же ветка, что и на обрыв.
+      const error = fromSuperagent({ error: true, timeout: 5000 })
+
+      expect(error).toBeInstanceOf(DisconnectedError)
+    })
+  })
+
+  describe('исключения, не связанные с ответом сервера', () => {
+    it('ошибка без поля error преобразуется в UnknownError', () => {
+      // Связка Superagent + OpenApi Middleware бросает, например,
+      // "data.map is not a function" — в таком исключении поля error нет.
+      const error = fromSuperagent(new TypeError('data.map is not a function'))
+
+      expect(error).toBeInstanceOf(UnknownError)
+    })
+
+    it('произвольный объект без поля error даёт UnknownError', () => {
+      const error = fromSuperagent({ response: { status: 404 } })
+
+      expect(error).toBeInstanceOf(UnknownError)
+    })
+  })
+
+  describe('некорректный вход', () => {
+    // Известный дефект (#66), парный к такому же в axios-билдере.
+    it.fails('null преобразуется в UnknownError', () => {
+      expect(fromSuperagent(null)).toBeInstanceOf(UnknownError)
+    })
+
+    it.fails('undefined преобразуется в UnknownError', () => {
+      expect(fromSuperagent(undefined)).toBeInstanceOf(UnknownError)
+    })
+
+    it('сейчас на null выбрасывается TypeError', () => {
+      expect(() => fromSuperagent(null)).toThrow(TypeError)
+    })
+  })
+})


### PR DESCRIPTION
Closes #18

## Зачем

Тестами были покрыты только конструкторы классов ошибок — 11 файлов на
проверку того, что `new NotFoundError()` кладёт 404 в `status`. Вся реальная
логика пакета, разбор ответов axios и superagent, не проверялась вовсе.

Тесты написаны **под текущее поведение**, до исправлений из #66. Это
намеренно: они фиксируют базу, и следующий PR наглядно покажет, что именно
меняется.

## Что покрыто

74 теста на оба билдера: таблицы известных статусов, поведение на неизвестных
статусах, извлечение `details` из всех вариантов тела ответа, ветки обрыва
связи, реакция на чужие и некорректные ошибки.

Фикстуры собраны вручную обычными объектами — axios и superagent в
devDependencies не добавлялись.

Покрытие `src/builders` — 98.8%.

## Дефекты из #66 описаны через it.fails

Потерянный `details` для статуса 500 в superagent-билдере и падение обоих
билдеров на `null`. Тесты написаны под ожидаемое поведение и сейчас корректно
считаются провальными. После исправления понадобится снять только маркер.

Рядом с каждым лежит парный тест, фиксирующий текущее поведение, — чтобы
поломка была видна и в том случае, если `it.fails` кто-то просто удалит.

## Найдено попутно

Финальный `return new UnknownError()` в `fromSuperagent`
(`superagent-error-builder.js:111`) недостижим: отрицание `isDisconnect` уже
гарантирует наличие `response`, поэтому `hasServerError` всегда истинно. Это
единственное непокрытое место в билдерах — покрытие его и подсветило. Стоит
дописать в #66; сам файл в этом PR не трогал.

## Что документируют тесты, а не проверяют

Несколько тестов зафиксировали поведение, которое стоит менять в v4, — они
проходят, но описывают потери:

- неизвестный статус (422, 429, 502, 503, 504) даёт `UnknownError`, теряя и
  статус, и тело ответа;
- таймаут неотличим от обрыва связи — `code` не проверяется;
- отменённый запрос попадает в `UnknownError`;
- `{ detail: null }` из-за `??` возвращает всё тело целиком, а не `null`.

## Проверка

138 тестов в 13 файлах, все зелёные. `lint` и `format:check` чисты.