### PR TITLE
ci: публикация в GitHub переведена на встроенный токен

### DIFF
--- a/.gitea/workflows/release.yml
+++ b/.gitea/workflows/release.yml
@@ -117,6 +117,9 @@ jobs:
       - name: 🛠️ Build
         run: npm run build
 
+      # Здесь остаётся PAT, в отличие от GitHub. Автоматический GITEA_TOKEN
+      # не имеет авторизации на запись в реестр пакетов — документация Gitea
+      # прямо предписывает обходиться персональным токеном.
       - name: 🚀 Publish package to Gitea Registry
         run: npm publish --tag "${{ needs.validate.outputs.npm_tag }}"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,10 @@ jobs:
       - name: 🛠️ Build
         run: npm run build
 
+      # Встроенный токен вместо PAT: он не истекает, не требует ручного
+      # обновления и ограничен этим репозиторием. Права даёт блок
+      # permissions выше.
       - name: 🚀 Publish package to Github Registry
         run: npm publish --tag "${{ needs.validate.outputs.npm_tag }}"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# ci: публикация в GitHub переведена на встроенный токен

Closes #63

## Зачем

Ручной запуск публикации упал:

```
npm error code E401
npm error 401 Unauthorized - PUT https://npm.pkg.github.com/@andrey-aka-skif%2fapp-errors
npm error unauthenticated: User cannot be authenticated with the token provided.
```

Похоже на истёкший PAT. Это и есть изъян схемы: токен надо помнить,
продлевать и обновлять в секретах, а забывчивость обнаруживается только в
момент релиза.

Исходная формулировка #63 предлагала переименовать `NPM_PUBLISH_TOKEN` в
`PACKAGE_PUBLISH_TOKEN`. Имя менялось, проблема оставалась.

## Что изменено

**GitHub — встроенный токен.** `NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`.
Он не истекает, не требует сопровождения и ограничен репозиторием, из
которого запущен воркфлоу. Блок `permissions` с `packages: write` в job
публикации уже стоял, дополнительных настроек не нужно.

**Gitea — PAT остаётся.** Одинаково сделать не вышло. Автоматический токен
там есть, и ключ `permissions` поддерживается, но по пакетам документация
Gitea говорит прямо: «the `GITEA_TOKEN` currently lacks automatic "Package
repository authorization" for publishing packages, unlike GitHub's automatic
token permissions for package operations. Users must work around this using
Personal Access Tokens».

Расхождение помечено комментарием в файле — иначе читается как недоделка.

Имя секрета не меняю: после перехода он единственный и живёт только в
Gitea-воркфлоу, путать не с чем, а переименование потребовало бы завести
секрет руками.

## История вопроса

Переход на встроенный токен уже был (#38), затем возврат к PAT (#49). Оба
коммита трогали только `.github/`; Gitea всегда работала на PAT. Причина
возврата нигде не зафиксирована — то есть нельзя исключать, что тогда
`GITHUB_TOKEN` не сработал по своей причине.

Наиболее вероятная из таких причин — отсутствие связи пакета с
репозиторием. Связка выполняется по полю `repository` в `package.json`, оно
заполнено верно, но у пакета, созданного когда-то под PAT, она могла не
проставиться.

## На что смотреть

**Если прилетит 403 вместо 401** — это ровно тот случай. Лечится привязкой
пакета к репозиторию в настройках пакета либо повторной публикацией после
удаления. Версия 3.1.6 из реестра уже удалена вручную, так что чистая
публикация может проставить связку сама.

**Секрет `NPM_PUBLISH_TOKEN` в настройках GitHub-репозитория** после этого PR
не используется и может быть удалён. В Gitea он нужен и, судя по ошибке,
требует обновления.

**Восстановление удалённой версии.** Если 3.1.6 нужен обратно с `latest`,
документация GitHub даёт 30 дней: «You restore the package within 30 days of
its deletion» — при условии, что namespace не занят новым пакетом.
Переиздать ту же версию может не получиться.