### PR TITLE
ci: dist-тег latest достаётся только старшей версии

### DIFF
--- a/.gitea/workflows/release.yml
+++ b/.gitea/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
         id: resolve
         run: |
           TAG="${{ inputs.tag || github.event.release.tag_name }}"
-          NPM_TAG="${{ inputs.npm_tag || 'latest' }}"
 
           if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "❌ Неверный формат тега: $TAG"
@@ -60,6 +59,24 @@ jobs:
           if ! git show-ref --tags --quiet "refs/tags/$TAG"; then
             echo "❌ Тег не существует: $TAG"
             exit 1
+          fi
+
+          # dist-tag: latest достаётся только старшей версии. Патч линии
+          # сопровождения, выпущенный после новой мажорной, иначе увёл бы
+          # latest назад.
+          if [ -n "${{ inputs.npm_tag }}" ]; then
+            NPM_TAG="${{ inputs.npm_tag }}"
+          elif [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            NPM_TAG='next'
+          else
+            HIGHEST=$(git tag --list 'v*' --sort=v:refname \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | tail -n 1)
+            if [ "$TAG" = "$HIGHEST" ]; then
+              NPM_TAG='latest'
+            else
+              NPM_TAG="${TAG%%.*}-lts"
+              echo "ℹ️ $TAG не старший тег (старший — $HIGHEST)"
+            fi
           fi
 
           echo "ref=refs/tags/$TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,6 @@ jobs:
         id: resolve
         run: |
           TAG="${{ inputs.tag || github.event.release.tag_name }}"
-          NPM_TAG="${{ inputs.npm_tag || 'latest' }}"
 
           if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "❌ Неверный формат тега: $TAG"
@@ -58,6 +57,24 @@ jobs:
           if ! git show-ref --tags --quiet "refs/tags/$TAG"; then
             echo "❌ Тег не существует: $TAG"
             exit 1
+          fi
+
+          # dist-tag: latest достаётся только старшей версии. Патч линии
+          # сопровождения, выпущенный после новой мажорной, иначе увёл бы
+          # latest назад.
+          if [ -n "${{ inputs.npm_tag }}" ]; then
+            NPM_TAG="${{ inputs.npm_tag }}"
+          elif [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            NPM_TAG='next'
+          else
+            HIGHEST=$(git tag --list 'v*' --sort=v:refname \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | tail -n 1)
+            if [ "$TAG" = "$HIGHEST" ]; then
+              NPM_TAG='latest'
+            else
+              NPM_TAG="${TAG%%.*}-lts"
+              echo "ℹ️ $TAG не старший тег (старший — $HIGHEST)"
+            fi
           fi
 
           echo "ref=refs/tags/$TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# ci: dist-тег latest достаётся только старшей версии

Closes #76

Нужно влить до выпуска 4.0.0.

## Зачем

`npm publish --tag latest` был зашит жёстко. Пока выпускается только старшая
версия, это верно. Но после выхода 4.0.0 первый же патч в линии
сопровождения — релиз с тегом `v3.2.1` — увёл бы `latest` обратно на тройку,
и `npm install` без указания версии начал бы ставить старую мажорную.

Мина заряжена и под существующую `release/v2`.

## Что изменено

При релизе тег сравнивается со старшим тегом репозитория:

- совпал — публикация в `latest`;
- не совпал — в dist-тег линии вида `v3-lts`, с пояснением в логе.

Сравнение идёт по `git tag --sort=v:refname` на полной истории тегов
(`fetch-depth: 0` уже стоял). Обращение к реестру не требуется.

Заодно предрелиз уходит в `next`. Проверка формата пропускает только
`vX.Y.Z`, поэтому предрелиз старшей версии иначе забрал бы `latest`.

Ручной запуск по-прежнему берёт dist-тег из параметра, по умолчанию
`replay` — поведение не изменилось.

## Проверка

Логика прогнана локально на реальном списке тегов и на смоделированном
будущем:

| тег | предрелиз | параметр | dist-тег |
|---|---|---|---|
| v3.2.0 | — | — | `latest` |
| v3.1.6 | — | — | `v3-lts` |
| v3.1.6 | — | `replay` | `replay` |
| v4.0.0 (есть v3.2.1) | — | — | `latest` |
| v3.2.1 (есть v4.0.0) | — | — | `v3-lts` |
| v4.1.0 | да | — | `next` |

YAML валиден, `format:check` проходит.

## На что смотреть

**Имя dist-тега линии — `v3-lts`.** Выводится из мажорной части тега. Если
предпочтительнее другая схема (`legacy`, `v3.x`), это одна строка.

**Проверить можно только выпуском.** Первым безопасным случаем будет патч в
`release/v3` после 4.0.0 — до тех пор ветка `latest` работает как раньше.
Ручной запуск с явным `replay` условную логику не задействует.

**В Gitea** `github.event.release.prerelease` может не резолвиться. Тогда
ветка предрелиза просто не сработает и выбор пойдёт по сравнению тегов —
поведение остаётся корректным.