### PR TITLE
chore: дымовая проверка dist переведена на обе сборки

### DIFF
--- a/scripts/verify-dist.js
+++ b/scripts/verify-dist.js
@@ -5,30 +5,17 @@
  * минификатор. Именно там ломаются имена классов: сборщик может превратить
  * объявление класса в присваивание анонимного выражения, и тогда имя
  * подхватывается из имени переменной, которое минификатор сокращает.
- * Проверяем то, что реально уезжает потребителю.
+ * Проверяем то, что реально уезжает потребителю, — обе сборки, ESM и UMD:
+ * terser проходит по каждой отдельно.
+ *
+ * Эталон берётся из src/index.js, а не из зашитого перечня: ручной список
+ * молча пропустил бы вновь добавленный класс.
  */
 
 import { readdirSync } from 'node:fs'
 import { fileURLToPath, URL } from 'node:url'
 
 const DIST = fileURLToPath(new URL('../dist', import.meta.url))
-
-/** Классы, создаваемые без обязательных аргументов. */
-const NULLARY_CLASSES = [
-  'UnknownError',
-  'DisconnectedError',
-  'TimeoutError',
-  'CanceledError',
-  'HttpError',
-  'BadRequestError',
-  'UnauthorizedError',
-  'ForbiddenError',
-  'NotFoundError',
-  'ConflictError',
-  'UnprocessableEntityError',
-  'TooManyRequestsError',
-  'InternalServerError',
-]
 
 const failures = []
 
@@ -38,12 +25,13 @@ const check = (condition, message) => {
   }
 }
 
-const checkThrows = (fn, ErrorClass, message) => {
-  try {
-    fn()
-    failures.push(message)
-  } catch (error) {
-    check(error instanceof ErrorClass, message)
+const report = () => {
+  if (failures.length > 0) {
+    console.error('❌ Проверка собранного пакета не пройдена:')
+    for (const failure of failures) {
+      console.error(`   - ${failure}`)
+    }
+    process.exit(1)
   }
 }
 
@@ -51,102 +39,115 @@ const files = readdirSync(DIST)
 check(files.includes('index.es.js'), 'В dist/ нет index.es.js')
 check(files.includes('index.umd.js'), 'В dist/ нет index.umd.js')
 
+// Без файлов проверять нечего: дальше их пришлось бы загружать.
+report()
+
+const src = await import('../src/index.js')
+
+const EXPECTED_EXPORTS = Object.keys(src).sort()
+
+// Отбор по цепочке прототипов, а не по виду имени: BaseAppError отсеивается
+// как не наследник самого себя, билдеры — как стрелочные функции без prototype.
+const ERROR_CLASSES = Object.entries(src)
+  .filter(([, value]) => value?.prototype instanceof src.BaseAppError)
+  .map(([name]) => name)
+
+const instantiate = (label, className, ErrorClass) => {
+  try {
+    return new ErrorClass()
+  } catch {
+    // Класс с обязательным сообщением (LogicError) без аргументов не создаётся.
+  }
+
+  try {
+    return new ErrorClass('дымовая проверка')
+  } catch (error) {
+    failures.push(
+      `${label}/${className}: экземпляр не создан — ${error.message}`
+    )
+    return null
+  }
+}
+
+const verifyBundle = (label, bundle) => {
+  check(
+    JSON.stringify(Object.keys(bundle).sort()) ===
+      JSON.stringify(EXPECTED_EXPORTS),
+    `${label}: набор экспортов разошёлся с src/index.js — ${Object.keys(bundle).sort().join(', ')}`
+  )
+
+  check(
+    JSON.stringify(bundle.ERROR_TYPE) === JSON.stringify(src.ERROR_TYPE),
+    `${label}: ERROR_TYPE разошёлся с исходником — ${JSON.stringify(bundle.ERROR_TYPE)}`
+  )
+
+  // Проверка до цикла: без BaseAppError каждый instanceof ниже дал бы
+  // TypeError вместо сообщения о причине.
+  if (typeof bundle.BaseAppError !== 'function') {
+    failures.push(
+      `${label}: экспорт BaseAppError отсутствует, классы проверить нечем`
+    )
+    return
+  }
+
+  for (const className of ERROR_CLASSES) {
+    const ErrorClass = bundle[className]
+
+    if (typeof ErrorClass !== 'function') {
+      failures.push(`${label}: экспорт ${className} отсутствует в сборке`)
+      continue
+    }
+
+    const instance = instantiate(label, className, ErrorClass)
+
+    if (!instance) {
+      continue
+    }
+
+    check(
+      instance.name === className,
+      `${label}/${className}: name равен "${instance.name}" вместо "${className}"`
+    )
+    // Сравнение с BaseAppError своей сборки: у ESM и UMD это разные классы.
+    check(
+      instance instanceof bundle.BaseAppError,
+      `${label}/${className}: экземпляр не является BaseAppError`
+    )
+  }
+
+  // Билдеры должны переживать сборку целиком, а не только по частям.
+  // Логика их ветвления проверена юнит-тестами по src/.
+  check(
+    bundle.fromAxios({
+      isAxiosError: true,
+      response: { status: 404, data: { detail: 'нет такого' } },
+    }) instanceof bundle.NotFoundError,
+    `${label}: fromAxios не вернул NotFoundError для статуса 404`
+  )
+  check(
+    bundle.fromSuperagent(null) instanceof bundle.UnknownError,
+    `${label}: fromSuperagent не устоял на аргументе null`
+  )
+}
+
 // Именно href: динамический import на Windows не принимает путь вида "D:\...".
-const pkg = await import(new URL('../dist/index.es.js', import.meta.url).href)
+verifyBundle(
+  'ESM',
+  await import(new URL('../dist/index.es.js', import.meta.url).href)
+)
 
-const checkInstance = (className, instance) => {
-  check(
-    instance.name === className,
-    `${className}: name равен "${instance.name}" вместо "${className}"`
-  )
-  check(
-    instance instanceof pkg.BaseAppError,
-    `${className}: экземпляр не является BaseAppError`
-  )
+// UMD-сборка не экспортирует ничего по-модульному: при загрузке она кладёт
+// экспорты в globalThis под именем из build.lib.name.
+await import(new URL('../dist/index.umd.js', import.meta.url).href)
+
+if (globalThis.appErrors) {
+  verifyBundle('UMD', globalThis.appErrors)
+} else {
+  failures.push('UMD-сборка не завела globalThis.appErrors')
 }
 
-for (const className of NULLARY_CLASSES) {
-  const ErrorClass = pkg[className]
+report()
 
-  if (!ErrorClass) {
-    failures.push(`Экспорт ${className} отсутствует в сборке`)
-    continue
-  }
-
-  checkInstance(className, new ErrorClass())
-}
-
-// Класс с обязательным аргументом проверяется отдельно: вызов без аргументов
-// у него выбрасывает TypeError.
-checkInstance('LogicError', new pkg.LogicError('дымовая проверка'))
-
-checkThrows(
-  () => new pkg.LogicError(),
-  TypeError,
-  'LogicError без сообщения не выбросил TypeError'
+console.log(
+  '✅ Собранный пакет проверен: обе сборки, имена классов и билдеры на месте'
 )
-
-// Билдеры должны переживать сборку целиком, а не только по частям.
-const source = {
-  isAxiosError: true,
-  response: { status: 404, data: { detail: 'нет такого' } },
-}
-const notFound = pkg.fromAxios(source)
-check(
-  notFound instanceof pkg.NotFoundError,
-  'fromAxios не вернул NotFoundError для статуса 404'
-)
-check(notFound instanceof pkg.HttpError, 'NotFoundError не наследует HttpError')
-check(
-  notFound.details === 'нет такого',
-  `fromAxios потерял details: ${JSON.stringify(notFound.details)}`
-)
-check(
-  notFound.message === 'Not Found',
-  `fromAxios потерял причинную фразу: ${notFound.message}`
-)
-check(notFound.cause === source, 'fromAxios не передал исходную ошибку в cause')
-
-// Статус, для которого нет отдельного класса, должен сохраняться.
-const badGateway = pkg.fromAxios({
-  isAxiosError: true,
-  response: { status: 502, data: { detail: 'шлюз' } },
-})
-check(
-  badGateway instanceof pkg.HttpError && badGateway.status === 502,
-  `fromAxios потерял статус 502: ${badGateway.status}`
-)
-check(badGateway.details === 'шлюз', 'fromAxios потерял тело ответа для 502')
-
-check(
-  pkg.fromAxios({ isAxiosError: true, code: 'ERR_CANCELED' }) instanceof
-    pkg.CanceledError,
-  'fromAxios не опознал отменённый запрос'
-)
-check(
-  pkg.fromAxios({
-    isAxiosError: true,
-    code: 'ECONNABORTED',
-    request: {},
-  }) instanceof pkg.TimeoutError,
-  'fromAxios не опознал таймаут'
-)
-
-check(
-  pkg.fromAxios(null) instanceof pkg.UnknownError,
-  'fromAxios не устоял на аргументе null'
-)
-check(
-  pkg.fromSuperagent(null) instanceof pkg.UnknownError,
-  'fromSuperagent не устоял на аргументе null'
-)
-
-if (failures.length > 0) {
-  console.error('❌ Проверка собранного пакета не пройдена:')
-  for (const failure of failures) {
-    console.error(`   - ${failure}`)
-  }
-  process.exit(1)
-}
-
-console.log('✅ Собранный пакет проверен: имена классов и билдеры на месте')


### PR DESCRIPTION
## Зачем

`scripts/verify-dist.js` существует ради одного инварианта: бандлер превращает
объявление класса в анонимное выражение, и имя держится только на строковом
литерале `this.name`. Юнит-тесты гоняются по `src/` и этого не видят.

Проверка себя оправдывала, но проверяла не то. Половина файла дублировала
`tests/builders/*` — логику, которую минификатор не трогает. При этом UMD-сборка
ни разу не загружалась: проверялось только наличие файла, хотя это второй
артефакт у потребителя, со своим проходом terser.

Closes #92

## Что изменено

- Перечень классов и набор экспортов выводятся из `src/index.js`. Ручной список
  из 13 имён удалён — он был третьей копией того же перечня, и, в отличие от
  `tests/error-name.test.js`, без предохранителя на полноту. Отбор идёт по
  цепочке прототипов (`value?.prototype instanceof BaseAppError`), а не по виду
  имени: `BaseAppError` отсекается как не наследник себя, билдеры — как
  стрелочные функции без `prototype`.
- Проверка вынесена в `verifyBundle(label, bundle)` и прогоняется дважды: по ESM
  и по `globalThis.appErrors` после загрузки UMD-файла. Метка `ESM`/`UMD` уходит
  в каждое сообщение об ошибке.
- Добавлены сверка набора экспортов бандла с исходником, сверка `ERROR_TYPE` и
  ранний внятный отказ при пропаже `BaseAppError` — раньше на этом месте был бы
  `TypeError` изнутри `instanceof`.
- Убраны дубли юнит-тестов: `TypeError` у `LogicError`, `details`/причинная
  фраза/`cause` у 404, статус и тело у 502, карта `ERR_CANCELED`/`ECONNABORTED`,
  `fromAxios(null)`. От билдеров осталось по одному дымовому вызову на сборку.

Поставляемый код не изменился: `dist` после правки тот же, `scripts/` не входит
в `files` и до реестра не доезжает. Отсюда тип `chore`, а не `fix`, и отсутствие
записи в CHANGELOG.

## На что смотреть на ревью

- `instanceof` сравнивается с `BaseAppError` **той же** сборки: у ESM и UMD это
  разные объекты классов, перекрёстная проверка провалилась бы всегда.
- Создание экземпляра идёт с откатом на вызов с сообщением. Обязательный
  аргумент есть только у `LogicError`, но `Function.length` его не отличает —
  у `HttpError` она тоже равна единице. Альтернатива — ещё один ручной список,
  ровно то, от чего уходили.
- Скрипт теперь импортирует `src/index.js`. Для проверки собранного пакета это
  допустимо: он дев-инструмент, в публикуемый набор не входит.
- Файл не сократился вдвое, как предполагал issue: 153 строки против 152.
  Разбор на `verifyBundle`/`instantiate`/`report` и метки сборок съели то, что
  дало удаление дублей. Покрытие при этом шире.

## Проверено

`npm run build` (с `prebuild` prettier и `postbuild`), `npm run lint`,
`npm test` — 298 тестов, всё зелёное.

Скрипт проверен на срабатывание: временная порча `this.name` в `NotFoundError`
дала провал на обеих сборках; удаление `ConflictError` из собранного
`index.es.js` дало и расхождение набора экспортов, и отсутствующий экспорт.
Обе правки откачены, `dist` пересобран.