### PR TITLE
docs: журнал изменений закрыт записью 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Формат основан на [Keep a Changelog](https://keepachangelog.com/ru/1.1.0/).
 Этот проект придерживается [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Не выпущено]
+## [4.0.0] - 2026-08-09
 
 Ломающий пересмотр публичного API. Прежняя реализация теряла информацию
 в трёх местах: нераспознанный статус ответа схлопывался в `UnknownError`
@@ -196,7 +196,7 @@ _Версия не помечена тегом, ссылки на сравнен
   - `AppErrorViaSuperagent` (аналогично).
 - Первоначальная документация.
 
-[Не выпущено]: https://github.com/andrey-aka-skif/app-errors/compare/v3.2.0...HEAD
+[4.0.0]: https://github.com/andrey-aka-skif/app-errors/compare/v3.2.1...v4.0.0
 [3.2.0]: https://github.com/andrey-aka-skif/app-errors/compare/v3.1.6...v3.2.0
 [3.1.6]: https://github.com/andrey-aka-skif/app-errors/compare/v3.1.3...v3.1.6
 [3.1.3]: https://github.com/andrey-aka-skif/app-errors/compare/v3.1.0...v3.1.3


### PR DESCRIPTION
# docs: журнал изменений закрыт записью 4.0.0

Closes #101

## Зачем

Подготовка к выпуску v4.0.0: раздел «Не выпущено» должен стать датированной
записью версии до создания релиза, иначе тег уедет с журналом, в котором
изменения формально не выпущены.

## Что изменено

- Заголовок `## [Не выпущено]` заменён на `## [4.0.0] - 2026-08-09`.
  Содержимое раздела не трогалось.
- Ссылка сравнения `[Не выпущено]` заменена на `[4.0.0]` с диапазоном
  `v3.2.1...v4.0.0`.

## На что смотреть на ревью

- База сравнения — `v3.2.1`, последний существующий тег, а не `v3.2.0`.
  Записи о 3.2.1 в журнале нет: тот тег нёс только правки CI и сборочной
  проверки, без изменений в публикуемом коде. Если решаем, что запись
  о 3.2.1 нужна, её стоит добавить в этой же ветке.
- Дата записи — 2026-08-09. Если релиз выпускается другим днём, её нужно
  поправить перед созданием тега.