### PR TITLE
docs: журнал изменений закрыт записью 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,21 @@
 Формат основан на [Keep a Changelog](https://keepachangelog.com/ru/1.1.0/).
 Этот проект придерживается [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Не выпущено]
+## [3.2.1] - 2026-08-09
+
+Выпуск линии сопровождения: код пакета не изменился, правки затрагивают
+только публикацию и проверку сборки.
+
+### Изменено
+
+- Dist-тег при публикации определяется сравнением тега релиза со старшим
+  тегом репозитория: старший идёт в `latest`, патч линии сопровождения — в
+  тег вида `v3-lts`, предрелиз — в `next`. Раньше `latest` был зашит жёстко,
+  и выпуск патча 3.x после 4.0.0 увёл бы `latest` на тройку.
+- Воркфлоу публикации переименован из `release.yml` в `publish.yml`, файлы
+  для GitHub и Gitea приведены к общему виду.
+- Дымовая проверка `verify:dist` гоняет обе сборки — ES и UMD, а не только
+  ES.
 
 ## [3.2.0] - 2026-08-08
 
@@ -127,7 +141,7 @@ _Версия не помечена тегом, ссылки на сравнен
   - `AppErrorViaSuperagent` (аналогично).
 - Первоначальная документация.
 
-[Не выпущено]: https://github.com/andrey-aka-skif/app-errors/compare/v3.2.0...HEAD
+[3.2.1]: https://github.com/andrey-aka-skif/app-errors/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/andrey-aka-skif/app-errors/compare/v3.1.6...v3.2.0
 [3.1.6]: https://github.com/andrey-aka-skif/app-errors/compare/v3.1.3...v3.1.6
 [3.1.3]: https://github.com/andrey-aka-skif/app-errors/compare/v3.1.0...v3.1.3


### PR DESCRIPTION
# docs: журнал изменений закрыт записью 3.2.1

Closes #103

**База PR — `release/v3`, не `master`.**

## Зачем

Подготовка к выпуску v3.2.1 из линии сопровождения: раздел «Не выпущено»
закрывается датированной записью до создания релиза.

## Что изменено

- `## [Не выпущено]` → `## [3.2.1] - 2026-08-09` с описанием четырёх
  накопленных на ветке правок (dist-тег по старшинству версии, переименование
  воркфлоу в `publish.yml`, выравнивание GitHub/Gitea, проверка обеих сборок
  в `verify:dist`).
- Ссылка сравнения `[3.2.1]` с диапазоном `v3.2.0...v3.2.1`.

## На что смотреть на ревью

- Записи описывают только CI и проверку сборки: `src/` между v3.2.0 и
  вершиной ветки не менялся. Во вводном абзаце это сказано явно — если такой
  выпуск считать не стоящим записи, альтернатива только одна: не публиковать
  3.2.1 вовсе, но тогда правка dist-тега не доедет до линии 3.x.
- Дата 2026-08-09 — поправить, если релиз уйдёт другим днём.
- Прошлый тег v3.2.1 в репозитории удалён; релиз создаётся заново с этой
  вершины.