### PR TITLE
docs: из Readme убраны прежние имена dist-тега линии

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,10 +27,6 @@ npm install @andrey-aka-skif/app-errors@lts-v2
 npm install @andrey-aka-skif/app-errors@^2
 ```
 
-Прежние имена этого тега больше не обновляются и остались висеть на старых
-версиях: `lts_v2` — на 2.0.5, `v2-lts` — на последнем выпуске до
-переименования.
-
 ## Быстрый старт
 
 ```js


### PR DESCRIPTION
Closes #141.

Абзац перечислял `lts_v2` и `v2-lts` как замороженные указатели на старых
версиях. Метки удаляются из реестров вручную, так что абзац описывает то, чего
больше нет, — и раньше подсовывал читателю лишние имена вместо одного
актуального `lts-v2`.

Упоминание `v2-lts` в `CONTRIBUTING.md` оставлено: там оно объясняет, почему
имя dist-тега не может начинаться с `v`+цифра, а не предлагает им пользоваться.