### PR TITLE
ci: воркфлоу Gitea переведены на метку раннера node-24

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -12,10 +12,9 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    container:
-      # Мажор дублирует NODE_VERSION и правится вместе с ним.
-      image: node:24-bookworm
+    # Метку раннер отображает на образ node:24-bookworm. Мажор дублирует
+    # NODE_VERSION и правится вместе с ним.
+    runs-on: node-24
 
     steps:
       - name: Checkout

--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -6,14 +6,10 @@ on:
   push:
     branches: ['**']
 
-env:
-  # Active LTS: с 28.10.2025, EOL 28.04.2028
-  NODE_VERSION: '24.x'
-
 jobs:
   build:
-    # Метку раннер отображает на образ node:24-bookworm. Мажор дублирует
-    # NODE_VERSION и правится вместе с ним.
+    # Метку node-24 раннер отображает на образ node:24-bookworm.
+    # Active LTS: с 28.10.2025, EOL 28.04.2028.
     runs-on: node-24
 
     steps:
@@ -23,7 +19,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
       - name: Install dependencies

--- a/.gitea/workflows/publish.yml
+++ b/.gitea/workflows/publish.yml
@@ -26,10 +26,8 @@ env:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    container:
-      # Мажор дублирует NODE_VERSION и правится вместе с ним.
-      image: node:24-bookworm
+    # Метку node-24 раннер отображает на образ node:24-bookworm.
+    runs-on: node-24
 
     steps:
       # fetch-depth: 0 — нужен полный список тегов: dist-tag latest достаётся

--- a/.gitea/workflows/publish.yml
+++ b/.gitea/workflows/publish.yml
@@ -19,14 +19,13 @@ permissions:
   packages: write
 
 env:
-  # Active LTS: с 28.10.2025, EOL 28.04.2028
-  NODE_VERSION: '24.x'
   REGISTRY_URL: 'https://192.168.100.252:3000/api/packages/usov-andrey/npm/'
   NPM_SCOPE: '@andrey-aka-skif'
 
 jobs:
   publish:
     # Метку node-24 раннер отображает на образ node:24-bookworm.
+    # Active LTS: с 28.10.2025, EOL 28.04.2028.
     runs-on: node-24
 
     steps:
@@ -43,7 +42,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ env.NODE_VERSION }}
           cache: npm
           registry-url: ${{ env.REGISTRY_URL }}
           scope: ${{ env.NPM_SCOPE }}


### PR DESCRIPTION
Раннер Gitea на `midgard` выбирает образ сборки по метке, а не по блоку
`container` в воркфлоу. Меток `ubuntu-*` он не объявляет, поэтому job с
`runs-on: ubuntu-latest` не падает, а зависает в очереди без исполнителя.

Оба воркфлоу в `.gitea/workflows` переведены на `runs-on: node-24`; блок
`container` снят — метка и есть указание образа.

Вместе с ним убрана явная версия Node: в образе `node:24-bookworm` рантайм уже
стоит, а `setup-node` смотрит tool-cache, а не системный Node, и качал его
заново каждый прогон. Мажор при этом был записан в двух местах сразу. Теперь
версию задаёт только метка раннера, `node-version` и `env.NODE_VERSION` из
gitea-воркфлоу удалены. `setup-node` остаётся ради `cache: npm` и, в публикации,
ради `registry-url`/`scope` — эти входы не тронуты.

Проверено прогонами на этой ветке: метка сматчилась, образ вытянут, шаг Setup
Node.js ничего не скачивает и только восстанавливает кэш, `npm ci`, lint, тесты
и сборка зелёные. Отдельным временным шагом проверен выход во внутренний реестр
по TLS из контейнера задания — реестр отвечает; шаг снят перед PR.

`publish.yml` вживую до релиза не проверяется, у него триггер только на publish
Release. Его дельта совпадает с уже подтверждённой в CI.

Воркфлоу для GitHub не затронуты: там меток раннера нет, `runs-on: ubuntu-latest`
остаётся. Наборы `.github` и `.gitea` после этого расходятся осознанно.

Closes #126
